### PR TITLE
update internetgateway1 example to build on go1.4

### DIFF
--- a/cmd/example_internetgateway1/example_internetgateway1.go
+++ b/cmd/example_internetgateway1/example_internetgateway1.go
@@ -21,7 +21,7 @@ func main() {
 
 	for _, c := range clients {
 		dev := &c.ServiceClient.RootDevice.Device
-		srv := &c.ServiceClient.Service
+		srv := c.ServiceClient.Service
 		fmt.Println(dev.FriendlyName, " :: ", srv.String())
 		scpd, err := srv.RequestSCDP()
 		if err != nil {


### PR DESCRIPTION
the Service field on the ServiceClient is already _goupnp.Service, so taking the address makes it a *_goupnp.Service which no longer will dereference to call methods on type *goupnp.Service like String and RequestSCDP.

let me know if you have any contributing agreements or whatever.
