### PR TITLE
httpu client bind to specific address function

### DIFF
--- a/goupnp.go
+++ b/goupnp.go
@@ -1,11 +1,11 @@
 // goupnp is an implementation of a client for various UPnP services.
 //
 // For most uses, it is recommended to use the code-generated packages under
-// github.com/traetox/goupnp/dcps. Example use is shown at
-// http://godoc.org/github.com/traetox/goupnp/example
+// github.com/huin/goupnp/dcps. Example use is shown at
+// http://godoc.org/github.com/huin/goupnp/example
 //
 // A commonly used client is internetgateway1.WANPPPConnection1:
-// http://godoc.org/github.com/traetox/goupnp/dcps/internetgateway1#WANPPPConnection1
+// http://godoc.org/github.com/huin/goupnp/dcps/internetgateway1#WANPPPConnection1
 //
 // Currently only a couple of schemas have code generated for them from the
 // UPnP example XML specifications. Not all methods will work on these clients,
@@ -23,8 +23,8 @@ import (
 
 	"golang.org/x/net/html/charset"
 
-	"github.com/traetox/goupnp/httpu"
-	"github.com/traetox/goupnp/ssdp"
+	"github.com/huin/goupnp/httpu"
+	"github.com/huin/goupnp/ssdp"
 )
 
 // ContextError is an error that wraps an error with some context information.

--- a/goupnp.go
+++ b/goupnp.go
@@ -1,11 +1,11 @@
 // goupnp is an implementation of a client for various UPnP services.
 //
 // For most uses, it is recommended to use the code-generated packages under
-// github.com/huin/goupnp/dcps. Example use is shown at
-// http://godoc.org/github.com/huin/goupnp/example
+// github.com/traetox/goupnp/dcps. Example use is shown at
+// http://godoc.org/github.com/traetox/goupnp/example
 //
 // A commonly used client is internetgateway1.WANPPPConnection1:
-// http://godoc.org/github.com/huin/goupnp/dcps/internetgateway1#WANPPPConnection1
+// http://godoc.org/github.com/traetox/goupnp/dcps/internetgateway1#WANPPPConnection1
 //
 // Currently only a couple of schemas have code generated for them from the
 // UPnP example XML specifications. Not all methods will work on these clients,
@@ -23,8 +23,8 @@ import (
 
 	"golang.org/x/net/html/charset"
 
-	"github.com/huin/goupnp/httpu"
-	"github.com/huin/goupnp/ssdp"
+	"github.com/traetox/goupnp/httpu"
+	"github.com/traetox/goupnp/ssdp"
 )
 
 // ContextError is an error that wraps an error with some context information.

--- a/httpu/httpu.go
+++ b/httpu/httpu.go
@@ -3,6 +3,7 @@ package httpu
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -22,6 +23,20 @@ type HTTPUClient struct {
 // purpose.
 func NewHTTPUClient() (*HTTPUClient, error) {
 	conn, err := net.ListenPacket("udp", ":0")
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPUClient{conn: conn}, nil
+}
+
+// NewHTTPUClientAddr creates a new HTTPUClient which will broadcast packets
+// from the specified address, opening up a new UDP socket for the purpose
+func NewHTTPUClientAddr(addr string) (*HTTPUClient, error) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return nil, errors.New("Invalid listening address")
+	}
+	conn, err := net.ListenPacket("udp", ip.String()+":0")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I ran into a situation where issuing UPNP requests were going out the wrong interface, so I added a function here to allow for specifying the address that the httpu client binds to.  I did not modify the original NewHTTPUClient so it won't screw with compatibility.