### PR TITLE
Defer closing of xml file

### DIFF
--- a/gotasks/specgen_task.go
+++ b/gotasks/specgen_task.go
@@ -412,7 +412,7 @@ func unmarshalXmlFile(file *zip.File, data interface{}) error {
 		return err
 	}
 	decoder := xml.NewDecoder(r)
-	r.Close()
+	defer r.Close()
 	return decoder.Decode(data)
 }
 


### PR DESCRIPTION
`gotask specgen` with Go 1.7.3 on Darwin was giving the following errors:

```
gotask specgen
2016/10/25 10:15:28 Error processing spec for internetgateway1 in file "specs/internetgateway1.zip": error decoding device XML from file "xml test files/device/InternetGatewayDevice1.xml": Read after Close
2016/10/25 10:15:28 Error processing spec for internetgateway2 in file "specs/internetgateway2.zip": error decoding device XML from file "xml data files/device/InternetGatewayDevice1.xml": Read after Close
2016/10/25 10:15:28 Error processing spec for av1 in file "specs/av1.zip": error decoding device XML from file "xml data files/device/MediaRenderer1.xml": Read after Close
```

This fixes that issue.