### PR TITLE
Fix for max-age

### DIFF
--- a/ssdp/registry.go
+++ b/ssdp/registry.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	maxAgeRx = regexp.MustCompile("max-age= ?([0-9]+)")
+	maxAgeRx = regexp.MustCompile("max-age= *([0-9]+)")
 )
 
 const (

--- a/ssdp/registry.go
+++ b/ssdp/registry.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	maxAgeRx = regexp.MustCompile("max-age=([0-9]+)")
+	maxAgeRx = regexp.MustCompile("max-age= ?([0-9]+)")
 )
 
 const (


### PR DESCRIPTION
I had the case with my samsung TV, max-age header contains a space `max-age= 1800` and this fix resolved it.