### PR TITLE
Disable verbose logging of unexpected ssdp responses

### DIFF
--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -60,7 +60,7 @@ func SSDPRawSearch(httpu *httpu.HTTPUClient, searchTarget string, maxWaitSeconds
 			continue
 		}
 		if st := response.Header.Get("ST"); st != searchTarget {
-			log.Printf("ssdp: got unexpected search target result %q", st)
+			//log.Printf("ssdp: got unexpected search target result %q", st)
 			continue
 		}
 		location, err := response.Location()

--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -60,7 +60,6 @@ func SSDPRawSearch(httpu *httpu.HTTPUClient, searchTarget string, maxWaitSeconds
 			continue
 		}
 		if st := response.Header.Get("ST"); st != searchTarget {
-			//log.Printf("ssdp: got unexpected search target result %q", st)
 			continue
 		}
 		location, err := response.Location()


### PR DESCRIPTION
This seems unnecessary, and clutters up the log output.