### PR TITLE
Fix uint out of value parsing for > 4 GiB traffic usage

### DIFF
--- a/dcps/internetgateway1/internetgateway1.go
+++ b/dcps/internetgateway1/internetgateway1.go
@@ -1268,7 +1268,7 @@ func (client *WANCommonInterfaceConfig1) GetMaximumActiveConnections() (NewMaxim
 	return
 }
 
-func (client *WANCommonInterfaceConfig1) GetTotalBytesSent() (NewTotalBytesSent uint32, err error) {
+func (client *WANCommonInterfaceConfig1) GetTotalBytesSent() (NewTotalBytesSent uint64, err error) {
 	// Request structure.
 	request := interface{}(nil)
 	// BEGIN Marshal arguments into request.
@@ -1287,14 +1287,14 @@ func (client *WANCommonInterfaceConfig1) GetTotalBytesSent() (NewTotalBytesSent 
 
 	// BEGIN Unmarshal arguments from response.
 
-	if NewTotalBytesSent, err = soap.UnmarshalUi4(response.NewTotalBytesSent); err != nil {
+	if NewTotalBytesSent, err = soap.UnmarshalUi8(response.NewTotalBytesSent); err != nil {
 		return
 	}
 	// END Unmarshal arguments from response.
 	return
 }
 
-func (client *WANCommonInterfaceConfig1) GetTotalBytesReceived() (NewTotalBytesReceived uint32, err error) {
+func (client *WANCommonInterfaceConfig1) GetTotalBytesReceived() (NewTotalBytesReceived uint64, err error) {
 	// Request structure.
 	request := interface{}(nil)
 	// BEGIN Marshal arguments into request.
@@ -1313,7 +1313,7 @@ func (client *WANCommonInterfaceConfig1) GetTotalBytesReceived() (NewTotalBytesR
 
 	// BEGIN Unmarshal arguments from response.
 
-	if NewTotalBytesReceived, err = soap.UnmarshalUi4(response.NewTotalBytesReceived); err != nil {
+	if NewTotalBytesReceived, err = soap.UnmarshalUi8(response.NewTotalBytesReceived); err != nil {
 		return
 	}
 	// END Unmarshal arguments from response.

--- a/gotasks/specgen_task.go
+++ b/gotasks/specgen_task.go
@@ -43,6 +43,27 @@ var dcpMetadata = []DCPMetadata{
 		OfficialName: "Internet Gateway Device v1",
 		DocURL:       "http://upnp.org/specs/gw/UPnP-gw-InternetGatewayDevice-v1-Device.pdf",
 		XMLSpecURL:   "http://upnp.org/specs/gw/UPnP-gw-IGD-TestFiles-20010921.zip",
+		Hacks: []DCPHackFn{
+			func(dcp *DCP) error {
+				for _, service := range dcp.Services {
+					if service.URN == "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1" {
+						variables := service.SCPD.StateVariables
+						for key, variable := range variables {
+							varName := variable.Name
+							if varName == "TotalBytesSent" || varName == "TotalBytesReceived" {
+								// Fix size of total bytes which is by default ui4 or maximum 4 GiB.
+								variable.DataType.Name = "ui8"
+								variables[key] = variable
+							}
+						}
+
+						break
+					}
+				}
+
+				return nil
+			},
+		},
 	},
 	{
 		Name:         "internetgateway2",
@@ -370,6 +391,7 @@ var typeConvs = map[string]conv{
 	"ui1":         conv{"Ui1", "uint8"},
 	"ui2":         conv{"Ui2", "uint16"},
 	"ui4":         conv{"Ui4", "uint32"},
+	"ui8":         conv{"Ui8", "uint64"},
 	"i1":          conv{"I1", "int8"},
 	"i2":          conv{"I2", "int16"},
 	"i4":          conv{"I4", "int32"},

--- a/soap/types.go
+++ b/soap/types.go
@@ -47,6 +47,15 @@ func UnmarshalUi4(s string) (uint32, error) {
 	return uint32(v), err
 }
 
+func MarshalUi8(v uint64) (string, error) {
+	return strconv.FormatUint(v, 10), nil
+}
+
+func UnmarshalUi8(s string) (uint64, error) {
+	v, err := strconv.ParseUint(s, 10, 64)
+	return uint64(v), err
+}
+
 func MarshalI1(v int8) (string, error) {
 	return strconv.FormatInt(int64(v), 10), nil
 }


### PR DESCRIPTION
Currently when parsing the total bytes it returns a `uint32` which is basically `2^32 = 4,294,967,296 bytes = 4GiB`, which is not enough in many scenarios. So I changed it to uint64 which should be enough. 

The code I tested with
```go
	clients, err := internetgateway1.NewWANCommonInterfaceConfig1ClientsByURL(routerPath)
	if err != nil {
		log.Fatal("Error discovering service with UPnP:", err)
	}

	for _, client := range clients {
		if recv, err := client.GetTotalBytesReceived(); err != nil {
			log.Println("Error requesting bytes received:", err)
		} else {
			log.Println("Bytes received:", recv)
		}
	}
```

Error message I got before the patch
```
Error requesting bytes received: strconv.ParseUint: parsing "206099040008": value out of range
```

