### PR TITLE
Use totalBytesHack for intergateway2 too

### DIFF
--- a/dcps/internetgateway2/internetgateway2.go
+++ b/dcps/internetgateway2/internetgateway2.go
@@ -1734,7 +1734,7 @@ func (client *WANCommonInterfaceConfig1) GetMaximumActiveConnections() (NewMaxim
 	return
 }
 
-func (client *WANCommonInterfaceConfig1) GetTotalBytesSent() (NewTotalBytesSent uint32, err error) {
+func (client *WANCommonInterfaceConfig1) GetTotalBytesSent() (NewTotalBytesSent uint64, err error) {
 	// Request structure.
 	request := interface{}(nil)
 	// BEGIN Marshal arguments into request.
@@ -1753,14 +1753,14 @@ func (client *WANCommonInterfaceConfig1) GetTotalBytesSent() (NewTotalBytesSent 
 
 	// BEGIN Unmarshal arguments from response.
 
-	if NewTotalBytesSent, err = soap.UnmarshalUi4(response.NewTotalBytesSent); err != nil {
+	if NewTotalBytesSent, err = soap.UnmarshalUi8(response.NewTotalBytesSent); err != nil {
 		return
 	}
 	// END Unmarshal arguments from response.
 	return
 }
 
-func (client *WANCommonInterfaceConfig1) GetTotalBytesReceived() (NewTotalBytesReceived uint32, err error) {
+func (client *WANCommonInterfaceConfig1) GetTotalBytesReceived() (NewTotalBytesReceived uint64, err error) {
 	// Request structure.
 	request := interface{}(nil)
 	// BEGIN Marshal arguments into request.
@@ -1779,7 +1779,7 @@ func (client *WANCommonInterfaceConfig1) GetTotalBytesReceived() (NewTotalBytesR
 
 	// BEGIN Unmarshal arguments from response.
 
-	if NewTotalBytesReceived, err = soap.UnmarshalUi4(response.NewTotalBytesReceived); err != nil {
+	if NewTotalBytesReceived, err = soap.UnmarshalUi8(response.NewTotalBytesReceived); err != nil {
 		return
 	}
 	// END Unmarshal arguments from response.

--- a/gotasks/specgen_task.go
+++ b/gotasks/specgen_task.go
@@ -43,27 +43,7 @@ var dcpMetadata = []DCPMetadata{
 		OfficialName: "Internet Gateway Device v1",
 		DocURL:       "http://upnp.org/specs/gw/UPnP-gw-InternetGatewayDevice-v1-Device.pdf",
 		XMLSpecURL:   "http://upnp.org/specs/gw/UPnP-gw-IGD-TestFiles-20010921.zip",
-		Hacks: []DCPHackFn{
-			func(dcp *DCP) error {
-				for _, service := range dcp.Services {
-					if service.URN == "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1" {
-						variables := service.SCPD.StateVariables
-						for key, variable := range variables {
-							varName := variable.Name
-							if varName == "TotalBytesSent" || varName == "TotalBytesReceived" {
-								// Fix size of total bytes which is by default ui4 or maximum 4 GiB.
-								variable.DataType.Name = "ui8"
-								variables[key] = variable
-							}
-						}
-
-						break
-					}
-				}
-
-				return nil
-			},
-		},
+		Hacks:        []DCPHackFn{totalBytesHack},
 	},
 	{
 		Name:         "internetgateway2",
@@ -82,7 +62,7 @@ var dcpMetadata = []DCPMetadata{
 				}
 				dcp.ServiceTypes[missingURN] = urnParts
 				return nil
-			},
+			}, totalBytesHack,
 		},
 	},
 	{
@@ -91,6 +71,26 @@ var dcpMetadata = []DCPMetadata{
 		DocURL:       "http://upnp.org/specs/av/av1/",
 		XMLSpecURL:   "http://upnp.org/specs/av/UPnP-av-TestFiles-20070927.zip",
 	},
+}
+
+func totalBytesHack(dcp *DCP) error {
+	for _, service := range dcp.Services {
+		if service.URN == "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1" {
+			variables := service.SCPD.StateVariables
+			for key, variable := range variables {
+				varName := variable.Name
+				if varName == "TotalBytesSent" || varName == "TotalBytesReceived" {
+					// Fix size of total bytes which is by default ui4 or maximum 4 GiB.
+					variable.DataType.Name = "ui8"
+					variables[key] = variable
+				}
+			}
+
+			break
+		}
+	}
+
+	return nil
 }
 
 type DCPHackFn func(*DCP) error


### PR DESCRIPTION
As @zbisch pointed out my last pr only applied to internetgateway1. I didn't noticed the same code exists for internetgateway2 too. 

So I extracted the function and now apply it to both gateways. 