### PR TITLE
Corrected timeout err in httpu to flow upstream

### DIFF
--- a/httpu/httpu.go
+++ b/httpu/httpu.go
@@ -108,7 +108,7 @@ func (httpu *HTTPUClient) Do(req *http.Request, timeout time.Duration, numSends 
 		if err != nil {
 			if err, ok := err.(net.Error); ok {
 				if err.Timeout() {
-					break
+					return responses, err
 				}
 				if err.Temporary() {
 					// Sleep in case this is a persistent error to avoid pegging CPU until deadline.


### PR DESCRIPTION
Possible solution to #25.

Another way could be to create an err object in the beginning and use it through out.