### PR TITLE
Error discovering service with UPnP:  creating HTTPU client for address 169.254.220.204: listen udp 169.254.220.204:0: bind: The requested address is not valid in its context.

### DIFF
--- a/network.go
+++ b/network.go
@@ -48,7 +48,7 @@ func localIPv4MCastAddrs() ([]string, error) {
 	// Find the set of addresses to listen on.
 	var addrs []string
 	for _, iface := range ifaces {
-		if iface.Flags&net.FlagMulticast == 0 || iface.Flags&net.FlagLoopback != 0 {
+		if iface.Flags&net.FlagMulticast == 0 || iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
 			// Does not support multicast or is a loopback address.
 			continue
 		}


### PR DESCRIPTION
当网络不启用时 net.FlagUp == 0
Error discovering service with UPnP:  creating HTTPU client for address 169.254.220.204: listen udp 169.254.220.204:0: bind: The requested address is not valid in its context.

c, err := httpu.NewHTTPUClientAddr(addr)
		if err != nil {
			return nil, nil, ctxErrorf(err,
				"creating HTTPU client for address %s", addr)
		}