### PR TITLE
Improve error handling

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -185,9 +185,11 @@ type soapBody struct {
 
 // SOAPFaultError implements error, and contains SOAP fault information.
 type SOAPFaultError struct {
-	FaultCode   string `xml:"faultcode"`
-	FaultString string `xml:"faultstring"`
-	Detail      string `xml:"detail"`
+	FaultCode   string `xml:"faultCode"`
+	FaultString string `xml:"faultString"`
+	Detail      struct {
+		Raw []byte `xml:",innerxml"`
+	} `xml:"detail"`
 }
 
 func (err *SOAPFaultError) Error() string {

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -54,7 +54,7 @@ func (client *SOAPClient) PerformAction(actionNamespace, actionName string, inAc
 		return fmt.Errorf("goupnp: error performing SOAP HTTP request: %v", err)
 	}
 	defer response.Body.Close()
-	if response.StatusCode != 200 {
+	if response.StatusCode != 200 && response.ContentLength == 0 {
 		return fmt.Errorf("goupnp: SOAP request got HTTP %s", response.Status)
 	}
 
@@ -66,6 +66,8 @@ func (client *SOAPClient) PerformAction(actionNamespace, actionName string, inAc
 
 	if responseEnv.Body.Fault != nil {
 		return responseEnv.Body.Fault
+	} else if response.StatusCode != 200 {
+		return fmt.Errorf("goupnp: SOAP request got HTTP %s", response.Status)
 	}
 
 	if outAction != nil {


### PR DESCRIPTION
Currently the SOAP client returns opaque `fmt.Errorf` when the server responds with non-OK status. This PR changes the code to always parse the response body, as long as it's not empty.

It also fixes the SOAP Fault type to properly decode fields and allow to further assert the error details.