### PR TITLE
Remove direct dependency on charset reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ encountered as an [issue on this
 project](https://github.com/huin/goupnp/issues/new). If it just works, then
 please report at least minimal working functionality as an issue, and
 optionally contribute the metadata upstream.
+
+## Migrating due to Breaking Changes
+
+- \#40 introduced a breaking change to handling non-utf8 encodings, but removes a heavy
+  dependency on `golang.org/x/net` with charset encodings. If this breaks your usage of this
+  library, you can return to the old behavior by modifying the exported variable and importing
+  the package yourself:
+
+```go
+import (
+  "golang.org/x/net/html/charset"
+  "github.com/huin/goupnp"
+)
+
+func init() {
+  // should be modified before goupnp libraries are in use.
+  goupnp.CharsetReaderFault = charset.NewReaderLabel
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150
-	golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-	golang.org/x/text v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,4 @@
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150 h1:vlNjIqmUZ9CMAWsbURYl3a6wZbw7q5RHVvlXTNS/Bs8=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1 h1:Y/KGZSOdz/2r0WJ9Mkmz6NJBusp0kiNx1Cn82lzJQ6w=
-golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/goupnp.go
+++ b/goupnp.go
@@ -17,12 +17,12 @@ package goupnp
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/huin/goupnp/ssdp"
-	"golang.org/x/net/html/charset"
 )
 
 // ContextError is an error that wraps an error with some context information.
@@ -123,6 +123,11 @@ func DeviceByURL(loc *url.URL) (*RootDevice, error) {
 	return root, nil
 }
 
+// CharsetReaderDefault specifies the charset reader used while decoding the output
+// from a UPnP server. It can be modified in an init function to allow for non-utf8 encodings,
+// but should not be changed after requesting clients.
+var CharsetReaderDefault func(charset string, input io.Reader) (io.Reader, error)
+
 func requestXml(url string, defaultSpace string, doc interface{}) error {
 	timeout := time.Duration(3 * time.Second)
 	client := http.Client{
@@ -141,7 +146,7 @@ func requestXml(url string, defaultSpace string, doc interface{}) error {
 
 	decoder := xml.NewDecoder(resp.Body)
 	decoder.DefaultSpace = defaultSpace
-	decoder.CharsetReader = charset.NewReaderLabel
+	decoder.CharsetReader = CharsetReaderDefault
 
 	return decoder.Decode(doc)
 }


### PR DESCRIPTION
Adds a hook allowing for users to add a charset reader, and provides nil default which should be utf-8.
I'm not sure whether just exposing an init function or having a public variable which can be manually modified would be better, since `Init` semi implies that it should be called only on start-up, but it can be changed anytime.

r? @huin
Addresses #39