### PR TITLE
[soap] Enhance SOAPFaultError error unwrapping

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -202,5 +202,6 @@ type SOAPFaultError struct {
 }
 
 func (err *SOAPFaultError) Error() string {
-	return fmt.Sprintf("SOAP fault: %s", err.FaultString)
+	return fmt.Sprintf("SOAP fault. Code: %s | Explanation: %s | Detail: %s",
+		err.FaultCode, err.FaultString, string(err.Detail.Raw))
 }


### PR DESCRIPTION
Hey. Thanks for the great repo. I encountered a few errors on my router (Fritz!box Cable 6660) that had no faultString or faultCode. Only err.Detail.Raw helped me understand the issue. This PR enhances the visibility of this error type.

Cheers!