### PR TITLE
adding ModelType to Device

### DIFF
--- a/device.go
+++ b/device.go
@@ -51,6 +51,7 @@ type Device struct {
 	ModelDescription string    `xml:"modelDescription"`
 	ModelName        string    `xml:"modelName"`
 	ModelNumber      string    `xml:"modelNumber"`
+	ModelType        string    `xml:"modelType"`
 	ModelURL         URLField  `xml:"modelURL"`
 	SerialNumber     string    `xml:"serialNumber"`
 	UDN              string    `xml:"UDN"`


### PR DESCRIPTION
I noticed some UPNP xml files have a modelType, which I would like to have access to from goupnp.