### PR TITLE
Fix faultcode+faultstring and get UPnPError details

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -194,9 +194,13 @@ type soapBody struct {
 
 // SOAPFaultError implements error, and contains SOAP fault information.
 type SOAPFaultError struct {
-	FaultCode   string `xml:"faultCode"`
-	FaultString string `xml:"faultString"`
+	FaultCode   string `xml:"faultcode"`
+	FaultString string `xml:"faultstring"`
 	Detail      struct {
+		UPnPError struct {
+			Errorcode        int    `xml:"errorCode"`
+			ErrorDescription string `xml:"errorDescription"`
+		} `xml:"UPnPError"`
 		Raw []byte `xml:",innerxml"`
 	} `xml:"detail"`
 }

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -2,6 +2,7 @@ package soap
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -130,8 +131,8 @@ func TestUPnPError(t *testing.T) {
 	if testing.Verbose() {
 		t.Logf("%+v\n", err)
 	}
-	soapErr, ok := err.(*SOAPFaultError)
-	if !ok {
+	soapErr := &SOAPFaultError{}
+	if ok := errors.As(err, &soapErr); !ok {
 		t.Fatal("expected *SOAPFaultError")
 	}
 	if soapErr.FaultCode != "s:Client" {

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -147,12 +147,13 @@ func TestUPnPError(t *testing.T) {
 		t.Fatalf("unexpected UPnPError ErrorDescription: %s",
 			soapErr.Detail.UPnPError.ErrorDescription)
 	}
+
 	if !strings.EqualFold(string(soapErr.Detail.Raw), `
-							<UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
-								<errorCode>725</errorCode>
-								<errorDescription>OnlyPermanentLeasesSupported</errorDescription>
-							</UPnPError>
-`) {
+					<UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+						<errorCode>725</errorCode>
+						<errorDescription>OnlyPermanentLeasesSupported</errorDescription>
+					</UPnPError>
+				`) {
 		t.Fatalf("unexpected Detail.Raw, got:\n%s", string(soapErr.Detail.Raw))
 	}
 }


### PR DESCRIPTION
👋 A small PR that does two things:

1. Fixes the parsing of `faultcode`/`faultstring` fields. 
The change was introduced in this PR  but I'm not sure why? https://github.com/huin/goupnp/pull/38
You've also properly set them in `v2alpha`: https://github.com/huin/goupnp/blob/main/v2alpha/soap/envelope/envelope.go#L23:L24
And the specs clearly specify this case: https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf
See page 74 as well as examples pages 83 & 84.

2. Parses some details of the optional `UPnPError` element. This will allow consumers that want to inspect the error to be able to easily retrieve `errorCode` and `errorDescription`. The `Raw` field is still there as a catch-all. 