### PR TITLE
Add WithHTTPClient function for per-request client control

### DIFF
--- a/goupnp.go
+++ b/goupnp.go
@@ -153,7 +153,26 @@ var CharsetReaderDefault func(charset string, input io.Reader) (io.Reader, error
 
 // HTTPClient specifies the http.Client object used when fetching the XML from the UPnP server.
 // HTTPClient defaults the http.DefaultClient.  This may be overridden by the importing application.
+//
+// In order to override the HTTP client used on a per-request basis, use [WithHTTPClient].
 var HTTPClientDefault = http.DefaultClient
+
+type httpClientContextKey struct{}
+
+// WithHTTPClient returns a context with the HTTP client set. If c is nil, it
+// means to use the default HTTP client specified by [HTTPClientDefault].
+func WithHTTPClient(ctx context.Context, c *http.Client) context.Context {
+	return context.WithValue(ctx, httpClientContextKey{}, c)
+}
+
+// httpClient returns the HTTP client from context, or [HTTPClientDefault] if
+// not set or nil.
+func httpClient(ctx context.Context) *http.Client {
+	if c, ok := ctx.Value(httpClientContextKey{}).(*http.Client); ok && c != nil {
+		return c
+	}
+	return HTTPClientDefault
+}
 
 func requestXml(ctx context.Context, url string, defaultSpace string, doc interface{}) error {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -164,7 +183,7 @@ func requestXml(ctx context.Context, url string, defaultSpace string, doc interf
 		return err
 	}
 
-	resp, err := HTTPClientDefault.Do(req)
+	resp, err := httpClient(ctx).Do(req)
 	if err != nil {
 		return err
 	}

--- a/goupnp_test.go
+++ b/goupnp_test.go
@@ -1,0 +1,58 @@
+package goupnp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestWithHTTPClient(t *testing.T) {
+	// Override the default HTTP client for testing purposes, to make sure
+	// that we're returning that value (if it was changed) and not
+	// http.DefaultClient.
+	oldClient := HTTPClientDefault
+	t.Cleanup(func() {
+		HTTPClientDefault = oldClient
+	})
+	HTTPClientDefault = &http.Client{}
+
+	customClient := &http.Client{}
+	lastClient := &http.Client{}
+
+	ctx := t.Context()
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want *http.Client
+	}{
+		{
+			name: "no context value returns HTTPClientDefault",
+			ctx:  ctx,
+			want: HTTPClientDefault,
+		},
+		{
+			name: "context with custom client returns that client",
+			ctx:  WithHTTPClient(ctx, customClient),
+			want: customClient,
+		},
+		{
+			name: "context with nil client returns HTTPClientDefault",
+			ctx:  WithHTTPClient(ctx, nil),
+			want: HTTPClientDefault,
+		},
+		{
+			name: "nested contexts preserve last client",
+			ctx:  WithHTTPClient(WithHTTPClient(ctx, customClient), lastClient),
+			want: lastClient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := httpClient(tt.ctx)
+			if got != tt.want {
+				t.Errorf("httpClient() = %p, want %p", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If it's necessary to control the HTTP client on a per-request basis (instead of using the package-global HTTPClientDefault), there's currently no safe way to do this except serializing the HTTP requests and mutating the package global for each.

Add a WithHTTPClient function that sets a key in a context, and have requestXml read this context value if present when picking the HTTP client to use.